### PR TITLE
Fix stop info display

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,23 +48,17 @@ async function getBusStopInfo (busStopId) {
 
   const data = await resp.json()
 
-  for (const child of data.children) {
-    if (child.naptanId !== busStopId) {
-      continue
+  const commonName = data.commonName
+  const stopLetter = data.stopLetter
+
+  let towards = null
+  for (const addProp of data.additionalProperties) {
+    if (addProp.key === 'Towards') {
+      towards = addProp.value
     }
-
-    const commonName = child.commonName
-    const stopLetter = child.stopLetter
-
-    let towards = null
-    for (const addProp of child.additionalProperties) {
-      if (addProp.key === 'Towards') {
-        towards = addProp.value
-      }
-    }
-
-    return { commonName, stopLetter, towards }
   }
+
+  return { commonName, stopLetter, towards }
 }
 
 async function getArrivals (busStopId) {


### PR DESCRIPTION
This was showing all blank. It appears that TfL's API has changed where
the data are kept, so iterating through children is no longer necessary.
